### PR TITLE
Add essential policies for cluster autoscaler pod

### DIFF
--- a/terraform/modules/galileo-eks/main.tf
+++ b/terraform/modules/galileo-eks/main.tf
@@ -16,13 +16,16 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
     sid = "ClusterAutoscaler"
 
     actions = [
-      "autoscaling:DescribeAutoScalingGroups",
-      "autoscaling:DescribeAutoScalingInstances",
-      "autoscaling:DescribeLaunchConfigurations",
-      "autoscaling:DescribeScalingActivities",
-      "autoscaling:SetDesiredCapacity",
-      "autoscaling:TerminateInstanceInAutoScalingGroup",
       "eks:DescribeNodegroup",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:DescribeScalingActivities",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeTags",
+      "ec2:DescribeLaunchTemplateVersions",
+      "ec2:DescribeInstanceTypes"
     ]
 
     resources = [


### PR DESCRIPTION
# Summary

Auto-scaling was broken on staging:

```
E0108 22:20:49.343094       1 aws_manager.go:259] Failed to regenerate ASG cache: cannot autodiscover ASGs: AccessDenied: User: arn:aws:sts::004899986442:assumed-role/galileo-core-eks-node-group-20231213221439136200000002/i-06baeb37c3c83f30d is not authorized to perform: autoscaling:DescribeTags because no identity-based policy allows the autoscaling:DescribeTags action
        status code: 403, request id: 9177d72e-6ee4-4f32-aa5d-1e27f6c41fa2
F0108 22:20:49.343121       1 aws_cloud_provider.go:330] Failed to create AWS Manager: cannot autodiscover ASGs: AccessDenied: User: arn:aws:sts::004899986442:assumed-role/galileo-core-eks-node-group-20231213221439136200000002/i-06baeb37c3c83f30d is not authorized to perform: autoscaling:DescribeTags because no identity-based policy allows the autoscaling:DescribeTags action
```

This was found by working through the [troubleshooting guide provided by AWS](https://repost.aws/knowledge-center/amazon-eks-troubleshoot-autoscaler).

# Testing

Manually modified the policy in staging, the cluster auto-scaling pod is now running:

```console
➜  deploy git:(main) ✗ kubectl get pods -n kube-system -w | grep cluster-autoscaler
cluster-autoscaler-66c69fc986-n8slb   1/1     Running             0                84s
```

The runners pods that were also previously unable to deploy new images are now able to properly cycle.