### PR TITLE
fix(resources): Core nodes are under-utilized, lower the min nodes

### DIFF
--- a/terraform/modules/galileo-eks/main.tf
+++ b/terraform/modules/galileo-eks/main.tf
@@ -80,9 +80,9 @@ module "eks_galileo" {
 
       disk_size = 200
 
-      min_size     = 4
-      max_size     = 6
-      desired_size = 5
+      min_size     = 2
+      max_size     = 5
+      desired_size = 3
       labels = {
         galileo-node-type = "galileo-core"
       }

--- a/terraform/modules/galileo-gke/main.tf
+++ b/terraform/modules/galileo-gke/main.tf
@@ -51,13 +51,13 @@ module "galileo_gke" {
       name               = "galileo-core"
       machine_type       = "e2-standard-4"
       image_type         = "COS_CONTAINERD"
-      min_count          = 4
+      min_count          = 2
       max_count          = 5
       disk_size_gb       = 300
       disk_type          = "pd-standard"
       auto_repair        = true
       auto_upgrade       = true
-      initial_node_count = 4
+      initial_node_count = 3
     },
     {
       name               = "galileo-runners"


### PR DESCRIPTION
Even on dev, we only use around 60% of the capacity
<img width="993" alt="image" src="https://github.com/rungalileo/galileo-infra-blueprints/assets/7556010/8f58dc19-f811-49e7-b3e8-8c5d02edf977">
