### PR TITLE
Add Dependabot configuration for Terraform module updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "terraform"
+    directory: "/terraform"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: "increase"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    rebase-strategy: "auto"


### PR DESCRIPTION
Add Dependabot configuration to monitor and update Terraform dependencies in the /terraform directory weekly. This will help ensure that the terraform-aws-modules/eks/aws module and other dependencies are kept up to date automatically.